### PR TITLE
chore: try fix ci

### DIFF
--- a/runner/src/utils.ts
+++ b/runner/src/utils.ts
@@ -153,7 +153,7 @@ export async function buildVite({
 }) {
   const $$ = $({ stdio: 'inherit', cwd: viteProjectPath })
   await $$`node -v`
-  await $$`pnpm i`
+  await $$`pnpm i --no-frozen-lockfile`
 
   console.log(colors.cyan(`Start run 'pnpm build' for Vite`))
   await $$`pnpm --filter vite build`


### PR DESCRIPTION
I think because we're using pnpm 8, but the fixture benchmark installs Vite that uses a different version of the lockfile, that's causing install failures. Added `pnpm i --no-frozen-lockfile` to hopefully fix it.